### PR TITLE
Algorithm fixes and formatting updates

### DIFF
--- a/AdoptionCall.md
+++ b/AdoptionCall.md
@@ -1,0 +1,9 @@
+# Proposal to Adopt as WG Documents
+
+We the authors of [Blind BBS Signatures](https://www.ietf.org/archive/id/draft-kalos-bbs-blind-signatures-01.html) and [BBS per Verifier Linkability (pseudonyms)](https://www.ietf.org/archive/id/draft-vasilis-bbs-per-verifier-linkability-01.html) would like to call for their adoption as CFRG working group documents. These documents build on the core [BBS Signature Scheme](https://www.ietf.org/archive/id/draft-irtf-cfrg-bbs-signatures-06.html) to provide important features necessary for privacy preserving digital credentials. Such privacy preserving digital credentials are being developed at the W3C [Data Integrity BBS Cryptosuites v1.0](https://w3c.github.io/vc-di-bbs/) (see section 4), and EUDI ARF see [cryptographer's feedback](https://github.com/user-attachments/files/15904122/cryptographers-feedback.pdf) with regards to pseudonymous authentication and non-transferability ("anonymous" holder binding).
+
+In addition, these drafts provide key features that can be used by higher level protocols that require anonymity and/or blind signature capabilities such as [privacy pass](https://datatracker.ietf.org/group/privacypass/about/)
+
+Best Regards
+
+Greg and Vasilis

--- a/DesignIssues.md
+++ b/DesignIssues.md
@@ -7,6 +7,8 @@ How best to implement the two flavors of pseudonyms? (a) issuer/signer known PID
 
 * Both types of pseudonyms must use the same proof verification procedure. This was my (Greg B) original requirement when I added hidden PID pseudonym.
 * Permit pseudonym feature to be combined with "anonymous holder binding" feature  or multiple holder/prover secret  messages. *Regardless* of  pseudonym type.
+* In the ABC4Trust requirements they have an **inspector** role that can de-anonymize the pseudonym by having the PID revealed. This could be the **issuer** but does not have to be. Hence it seems more general to always have a hidden pid and a procedure to reveal the hidden pid for a given credential.
+* In the hidden PID case we want to guard against duplication of PIDs or use of stolen PIDs. One way is to have the issuer check on this via secure a secure artifact. One way would be the holder creating an issuer-pseudonym, i.e., pseudo_issuer = H(issuer_public_id)*(holders_PID); And have the issuer check keep a table of these. Note this would have holder send (commitment, pseudo_issuer, proof of commitment and pseudonym)
 
 ## Current Approach
 
@@ -26,16 +28,22 @@ This approach is characterized by:
 1. Some would argue that my approach in step 4 above is a "hack", since we break the correspondence between messages and generators. Though in this case the message is zero.
 2. With the above approach we can't combine issuer known PID feature with anonymous holder binding (or other holder secrets) since this would produce message ordering such as (issuer messages, issuer pid, secret_prover_blind + signer_blind, holder committed  messages). Note that in the hidden PID case we can order as (issuer messages, secret_prover_blind + signer_blind, holder committed msgs, holder pid). This is under the one proof verification method assumption.
 
-## Alternative  Approach 1
+## Suggested Alternative  Approach
 
 Always use a committed PID with blind signing. In this approach the holder either receives the PID from the issuer or simply reveals the PID they have chosen to the issuer.  They then can add in as many committed secrets as they like, e.g., anonymous holder binding.
+
+Implementation suggestions/additions/details:
+
+1. Always have anonymous holder binding value (if used) be the first committed message and always have the (per credential) PID value be the last.
+2. Always compute an "issuer pseudonym" value, pseudo_issuer = H(issuer_public_id)*(holders_PID), to allow the issuer to guard against duplicate PIDs from different holders. Holders would send (PID commitment, pseudo_issuer, proof of commitment and pseudonym)
+3. Explicit PID reveal procedure. If issuer or 3rd party tracking is required. Provide a separate proof procedure that generates a proof that reveals just the PID value (and that the PID corresponds to the pseudonym). Recall the holder can reveal any of the blind signed messages of which the PID is the last.
 
 Pros:
 
 1. Unifies both flavors of PID completely.  Only difference is what is revealed to issuer.
-2. Issuer known PID can now work with anonymous holder binding and other committed messages.
-3. Only one  pseudonym verification function required
-4. Only one  pseudonym proof function required
+2. Issuer known PID can now work with anonymous holder binding and other committed messages. Can have an entity different from issuer do the tracking.
+3. Only one pseudonym verification function required
+4. Only one pseudonym proof function required
 
 Cons:
 

--- a/DesignIssues.md
+++ b/DesignIssues.md
@@ -39,9 +39,13 @@ Pros:
 
 Cons:
 
-1. Extra communication flow in issuer known PID case (holder to issuer)
-2. Extra commitment computation for holder in issuer known PID case compared to previous approach.
+1. Extra communication flow in issuer known PID case (holder to issuer). See *mitigation* below.
+2. Extra commitment computation for holder in issuer known PID case compared to previous approach. *Minor*
 3. Additional proof is needed that revealed PID (issuer known) is in the commitment in the proper place.
+
+### Simple Issuer Known PID (mitigation)
+
+In the case of issuer known PID **without** the holder having additional committed messages to sign the issuer can just generate the PID, commitment, and commitment with proof, and use these in the blind BBS sign procedure.  In order for the holder to  generate the psuedonym proof they only need the  PID and `secret_prover_blind` values  from the issuer.  Note since "blinding" the commitment isn't really necessary (the issuer  knows the PID) we should be able to set `secret_prover_blind` = 0.  Hence the information flow can remain as simple as existing approach.
 
 ## Alternative  Approach 2
 
@@ -50,7 +54,7 @@ Drop the requirement for only one pseudonym proof verify procedure or equivalent
 Pros:
 
 1. Keeps information flow in issuer known PID case simple
-2. Allows for issuer  known  PID to work with anonymous holder binding
+2. Allows for issuer  known  PID to work with anonymous holder binding. This is a more complicated information flow and would be equivalent to flow in Approach 1 for this case.
 
 Cons:
 

--- a/DesignIssues.md
+++ b/DesignIssues.md
@@ -51,6 +51,22 @@ Cons:
 2. Extra commitment computation for holder in issuer known PID case compared to previous approach. *Minor*
 3. Additional proof is needed that revealed PID (issuer known) is in the commitment in the proper place.
 
+### Other Ideas for PID uniqueness problem
+
+What if we use a "two part PID", i.e., have one part come from the issuer and the other part from the holder?
+
+#### Sum of two numbers
+
+Require the total PID to be 2*N number of bits. Have issuer generate a unique N bit number, $PID_i$, holder generates its N bit number, $PID_h$. The combined PID, $PID_c = (PID_i << N) + PID_h$. Or the reverse. But how do we prove to the issuer that the PID_c is of this form?
+
+Let G be a generator for the group. Note that $G^{PID_C} = G^{(PID_i << N )} * G^{PID_h}$ and by DL problem if the holder sends the issuer $G^{PID_h}$ and a proof they know the $PID_h$ that created this, the issuer cannot determine $PID_h$ but can check $G^{PID_C} * (1/(G^{PID_h)}) = G^{(PID_i << N )}$ But would we also need a "range proof" to insure that $PID_h$ is less than 2^N - 1? See Boneh and Shoup section 20.4.1
+Example: range proofs for a proof that "x is a d bit number".
+
+#### Multi-Part Pseudonym
+
+Again let there be $PID_i$ and $PID_h$ can we form a pseudonym based on these two values in a unique way? And furnish a proof of this. Let G and H be two **different** generators for the Group, what if we let $pseudo = G^{PID_i}*H^{PID_h}$ then the holder furnishes proof that they know the $PID_i$ and $PID_h$. Could we just have $G = curveHash(issuer_{pubId})$ and $H = curveHash(verifier_{pubId})$? For proof see Boneh and Shoup section 19.5.3
+"A Sigma protocol for arbitrary linear relations".
+
 ### Simple Issuer Known PID (mitigation)
 
 In the case of issuer known PID **without** the holder having additional committed messages to sign the issuer can just generate the PID, commitment, and commitment with proof, and use these in the blind BBS sign procedure.  In order for the holder to  generate the psuedonym proof they only need the  PID and `secret_prover_blind` values  from the issuer.  Note since "blinding" the commitment isn't really necessary (the issuer  knows the PID) we should be able to set `secret_prover_blind` = 0.  Hence the information flow can remain as simple as existing approach.

--- a/DesignIssues.md
+++ b/DesignIssues.md
@@ -1,0 +1,57 @@
+
+# Issues and Options for Pseudonyms
+
+How best to implement the two flavors of pseudonyms? (a) issuer/signer known PID, (b) hidden PID only known to holder/prover
+
+## Current and Possible Requirements
+
+* Both types of pseudonyms must use the same proof verification procedure. This was my (Greg B) original requirement when I added hidden PID pseudonym.
+* Permit pseudonym feature to be combined with "anonymous holder binding" feature  or multiple holder/prover secret  messages. *Regardless* of  pseudonym type.
+
+## Current Approach
+
+The current approach is available  [here](https://www.grotto-networking.com/files/draft-vasilis-bbs-per-verifier-linkability.html) and as a PR on Vasilis' repo.
+
+This approach is characterized by:
+
+1. Use of blind BBS signatures even in the case of issuer known PID
+2. Current blind BBS signature API will alway create at least one blind generator even if  there are no committed messages.
+3. Blind BBS domain calculation in [CoreBlindSign](https://www.ietf.org/archive/id/draft-kalos-bbs-blind-signatures-01.html#name-core-blind-sign) uses BBS domain calculation over combined list of generators (signer generators, blind generators)
+4. Issuer known PID proof message ordering: (issuer messages, issuer known PID), note that a zero for secret_prover_blind + signer_blind is **not** included. So we have a mismatch between number of messages and generators and we must remove the redundant check in step 8 of [BBS.ProofInit()](https://www.ietf.org/archive/id/draft-irtf-cfrg-bbs-signatures-06.html#name-proof-initialization), i.e., `if length(generators) != L + 1, return INVALID`.
+5. Hidden PID proof message ordering:  (issuer messages, secret_prover_blind + signer_blind, pid)
+6. Pseudonym  proof  verify function  [CoreProofVerifyWithPseudonym](https://www.grotto-networking.com/files/draft-vasilis-bbs-per-verifier-linkability.html#name-core-proof-verification) relies on the *PID value being the last proof message* so it can recover the `pid^` value needed in the pseudonym proof as seen in step 4.
+
+### Issues with Current Approach
+
+1. Some would argue that my approach in step 4 above is a "hack", since we break the correspondence between messages and generators. Though in this case the message is zero.
+2. With the above approach we can't combine issuer known PID feature with anonymous holder binding (or other holder secrets) since this would produce message ordering such as (issuer messages, issuer pid, secret_prover_blind + signer_blind, holder committed  messages). Note that in the hidden PID case we can order as (issuer messages, secret_prover_blind + signer_blind, holder committed msgs, holder pid). This is under the one proof verification method assumption.
+
+## Alternative  Approach 1
+
+Always use a committed PID with blind signing. In this approach the holder either receives the PID from the issuer or simply reveals the PID they have chosen to the issuer.  They then can add in as many committed secrets as they like, e.g., anonymous holder binding.
+
+Pros:
+
+1. Unifies both flavors of PID completely.  Only difference is what is revealed to issuer.
+2. Issuer known PID can now work with anonymous holder binding and other committed messages.
+3. Only one  pseudonym verification function required
+4. Only one  pseudonym proof function required
+
+Cons:
+
+1. Extra communication flow in issuer known PID case (holder to issuer)
+2. Extra commitment computation for holder in issuer known PID case compared to previous approach.
+3. Additional proof is needed that revealed PID (issuer known) is in the commitment in the proper place.
+
+## Alternative  Approach 2
+
+Drop the requirement for only one pseudonym proof verify procedure or equivalently send an  indicator of which of the two cases are being proved to the verifier.  Just put pid at end of either issuer messages or hidden (committed) messages. Use Blind signatures to allow for committed messages and features like anonymous holder binding. In issuer known PID case the last issuer message is the PID and  `pid^` can be found  via the **L** value used in blind BBS  proofs.  In the hidden PID case the PID is the last committed message.
+
+Pros:
+
+1. Keeps information flow in issuer known PID case simple
+2. Allows for issuer  known  PID to work with anonymous holder binding
+
+Cons:
+
+1. Requires two different proof verify procedures or extra info to be communicated and a  branch in proof verify.

--- a/DesignIssues.md
+++ b/DesignIssues.md
@@ -58,4 +58,4 @@ Pros:
 
 Cons:
 
-1. Requires two different proof verify procedures or extra info to be communicated and a  branch in proof verify.
+1. Requires two different proof verify procedures or extra info to be communicated and a branch in proof verify, i.e., additional primitives for devs to implement and maintain, when the other approach solves the use case without needing them.

--- a/DesignIssues.md
+++ b/DesignIssues.md
@@ -55,6 +55,12 @@ Cons:
 
 In the case of issuer known PID **without** the holder having additional committed messages to sign the issuer can just generate the PID, commitment, and commitment with proof, and use these in the blind BBS sign procedure.  In order for the holder to  generate the psuedonym proof they only need the  PID and `secret_prover_blind` values  from the issuer.  Note since "blinding" the commitment isn't really necessary (the issuer  knows the PID) we should be able to set `secret_prover_blind` = 0.  Hence the information flow can remain as simple as existing approach.
 
+### Proposed APIs Under This Approach
+
+1. Holder commits to arbitrary number of messages with a minimum of one. First message must be holder binding secret (if used), and last message must be PID.  Note proof of commitment contains number of committed messages. Need proof and mechanism to guarantee/check issuer uniqueness of PID.
+2. Signature Generation and Verification, ProofGen, ProofVerify
+3. PID reveal procedure/proof generation and verification.
+
 ## Alternative  Approach 2
 
 Drop the requirement for only one pseudonym proof verify procedure or equivalently send an  indicator of which of the two cases are being proved to the verifier.  Just put pid at end of either issuer messages or hidden (committed) messages. Use Blind signatures to allow for committed messages and features like anonymous holder binding. In issuer known PID case the last issuer message is the PID and  `pid^` can be found  via the **L** value used in blind BBS  proofs.  In the hidden PID case the PID is the last committed message.

--- a/draft-vasilis-bbs-per-verifier-linkability.md
+++ b/draft-vasilis-bbs-per-verifier-linkability.md
@@ -362,10 +362,9 @@ Procedure:
 
 1. messages.append(pid) // add pid to end of messages
 2. message_scalars = messages_to_scalars(messages, api_id)
-3. pid_scalar = messages_to_scalars((pid), api_id)
-4. generators = create_generators(length(messages) + 1, api_id) // includes one for pid
+3. generators = create_generators(length(messages) + 1, api_id) // includes one for pid
 
-5. proof = CoreProofGenWithPseudonym(PK,
+4. proof = CoreProofGenWithPseudonym(PK,
                                      signature,
                                      Pseudonym,
                                      verifier_id,
@@ -376,8 +375,8 @@ Procedure:
                                      disclosed_indexes,
                                      api_id)
 
-6. if proof is INVALID, return INVALID
-7. return proof
+5. if proof is INVALID, return INVALID
+6. return proof
 ```
 
 # Hidden PID BBS Pseudonym Interface
@@ -415,7 +414,7 @@ steps:
 
 ```
 1. committed_messages = [pid]
-1. result = BlindBBS.Verify(PK, signature, header, messages, committed_messages,
+2. result = BlindBBS.Verify(PK, signature, header, messages, committed_messages,
                                       secret_prover_blind, signer_blind)
 ```
 
@@ -498,19 +497,17 @@ Deserialization:
 Procedure:
 
 1.  message_scalars = ()
-2.  if secret_prover_blind != 0, message_scalars.append(
-                                     secret_prover_blind + signer_blind)
+2.  message_scalars.append(BBS.messages_to_scalars(messages, api_id))
+3.  message_scalars.append(secret_prover_blind + signer_blind)
     // The above addition must be done in the scalar field.
-3.  message_scalars.append(BBS.messages_to_scalars(
-                                   [pid], api_id))
-4.  message_scalars.append(BBS.messages_to_scalars(messages, api_id))
+4.  message_scalars.append(BBS.messages_to_scalars([pid], api_id))
 
 5.  generators = BBS.create_generators(L + 1, api_id)
 6.  blind_generators = BBS.create.create_generators(2, "BLIND_" + api_id)
 7.  generators.append(blind_generators)
 
 
-9. proof = CoreProofGenWithPseudonym(PK,
+8. proof = CoreProofGenWithPseudonym(PK,
                                      signature,
                                      Pseudonym,
                                      verifier_id,
@@ -521,8 +518,8 @@ Procedure:
                                      adj_disclosed_indexes,
                                      api_id)
 
-10. if proof is INVALID, return INVALID
-11. return proof
+9. if proof is INVALID, return INVALID
+10. return proof
 ```
 
 # Proof Verification with Pseudonym
@@ -595,7 +592,7 @@ Procedure:
 1. message_scalars = messages_to_scalars(disclosed_messages, api_id)
 2. generators = BBS.create_generators(L + 1, api_id)
 3. blind_generators = []
-4. if M > -1, bind_generators = BBS.create_generators(M + 1, "BLIND_" + api_id)
+4. bind_generators = BBS.create_generators(M + 1, "BLIND_" + api_id)
 5. generators.append(blind_generators)
 3. result = CoreProofVerifyWithPseudonym(PK,
                                          proof,
@@ -873,7 +870,6 @@ This document does not define new BBS ciphersuites. Its ciphersuite defined in [
 # IANA Considerations
 
 This document has no IANA actions.
-
 
 {backmatter}
 


### PR DESCRIPTION
This PR addresses the  following issues:

1. Issuer known pid proof generation procedure has a redundant pid_scalar computation.
2. In hidden pid proof generation procedure has an unnecessary test (if) on secret prover blind.
3. In hidden pid proof generation ordering of scalars is incorrect.
4. In proof verification with pseudonym should M < 0 now be considered an error? Compare to Blind proof verify. Currently no check. So will take it out for now.